### PR TITLE
Converting spaces to %20

### DIFF
--- a/commons_dco/utils.php
+++ b/commons_dco/utils.php
@@ -42,6 +42,7 @@ function runESQuery( $query )
 {
     $endpoint = "http://localhost:49200/dco/person/_search" ;
     $fullurl = $endpoint . "?q=$query" ;
+    $fullurl = str_replace( " ", "%20", $fullurl ) ;
     return runQuery( $fullurl ) ;
 }
 


### PR DESCRIPTION
Searching for a network id with a space in it returns nothing. Needed to replace spaces with %20.
